### PR TITLE
Add developer and installation guide

### DIFF
--- a/Developer-Guide.md
+++ b/Developer-Guide.md
@@ -1,0 +1,27 @@
+# Developer Guide
+This provides the installations required for the development of the kubernetes cost optimization operator.
+
+All pre-requisite components mentioned in [Installation Guide](Installation-Guide.md) should be installed based on the instructions.
+
+### Java
+
+SDKMan tool used to install java. Java operator SDK is developed in java version 17. Version 21 should be backward compatible with 17. If there is any blocking issues arise, the version can be rolled back to 17.
+
+* Version: 21
+
+This will list the available versions of java.
+>sdk list java
+
+Choose and install the required version as shown below,
+>sdk install java 21.0.6-zulu
+
+Verify that the java version is 21
+>java --version
+
+### Gradle
+
+Brew tool in Mac environment used for this installation.
+
+* Version: 8.13
+
+> brew install gradle

--- a/Installation-Guide.md
+++ b/Installation-Guide.md
@@ -1,0 +1,45 @@
+# Installation Guide
+This provides the pre-requisites and the actual installation details for this operator.
+This project is developed in the Mac environment and the instructions are recorded based on the Mac environment.
+
+## Pre Requisites
+This provides the list of component required for this project development and deployment.
+
+### Kubernetes
+Docker Desktop installation provides a Kubernetes installation. This can be enabled using the setting option in the docker desktop GUI.
+
+* Version: 1.32.2
+* Flavour: Docker Desktop
+
+#### Helm
+Brew tool in Mac environment used for this installation.
+
+* Version: 3.17.2
+
+> brew install Helm
+
+
+### Kubernetes Metrics Server
+
+This installation enables Kubernetes to record the memory and cpu usage of the pods/nodes.
+
+Verify that the metrics server is installed already using the command below. This will indicate if the metrics server is not installed.
+
+>kubectl top node 
+
+Download the metrics-server yaml from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.2/components.yaml and save it as [metrics-server.yaml](scripts/k8s/metrics-server.yaml).
+
+Modify this file to enable insecure-tls as described here https://github.com/kubernetes-sigs/metrics-server
+
+Create metrics server using the following command.
+
+>kubectl apply -f metrics-server.yaml
+
+Once installaed verify the metrics server installation as show below,
+
+>kubectl top node
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# kubernetes-cost-optimization-operator
+# Kubernetes Cost Optimization Operator
 A lightweight, Kubernetes-native operator designed to monitor and optimize resource usage in Kubernetes clusters. 
+
+## Documentation
+
+* [Installation Guide](Installation-Guide.md)
+* [Developer Guide](Developer-Guide.md)

--- a/scripts/k8s/metrics-server.yaml
+++ b/scripts/k8s/metrics-server.yaml
@@ -1,0 +1,202 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+      - args:
+        - --cert-dir=/tmp
+        - --secure-port=10250
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-use-node-status-port
+        - --metric-resolution=15s
+        - --kubelet-insecure-tls
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        name: metrics-server
+        ports:
+        - containerPort: 10250
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+      - emptyDir: {}
+        name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100


### PR DESCRIPTION
## Description
Developer guide and installation guides are added. Developer guide is meant to be used by developer to setup the operator development environment. Installation guide should guide the user to install the kubernetes cost operator. This covers the following components.
- Kubernetes
- Kubernetes Metrics Server
- Helm
- Java
- Gradle

## Changes
* Add new files for developer and installation guides.
* Add the metrics server yaml file used for the metrics server installation.
* Refer developer and installation guides from root README.md

## Related Issues
* This is part of the ongoing project setup #1 

## Testing
* Verified that the linking between the document works and the documents appear as expected

## Checklist (Use/Change where applicable)
* [ ] I have tested the changes.