### PR TITLE
Metrics server availability check before starting the operator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ ext {
     log4jVersion = "2.20.0"
     junitVersion = "5.9.2"
     fabric8Version = "7.1.0"
+    mockitoVersion = "5.17.0"
 }
 
 repositories {
@@ -29,10 +30,7 @@ repositories {
 
 dependencies {
     // Java Operator SDK
-    implementation("io.javaoperatorsdk:operator-framework:$josdkVersion") {
-        // https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx
-        exclude group: 'io.fabric8', module: 'kubernetes-httpclient-vertx'
-    }
+    implementation("io.javaoperatorsdk:operator-framework:$josdkVersion")
 
     // Operator SDK JUnit 5 support
     testImplementation("io.javaoperatorsdk:operator-framework-junit-5:$josdkVersion")
@@ -49,9 +47,17 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
+    testImplementation("io.fabric8:kubernetes-server-mock:$fabric8Version")
 
     // CRD generation (runtime dependencies)
     implementation("io.fabric8:crd-generator-api-v2:$fabric8Version")
+}
+
+configurations.configureEach {
+    // https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx
+    exclude group: 'io.fabric8', module: 'kubernetes-httpclient-vertx'
 }
 
 java {
@@ -74,14 +80,14 @@ jib {
     from {
         image = "eclipse-temurin:21-jdk"
         platforms {
-                platform {
-                    architecture = 'amd64'
-                    os = 'linux'
-                }
-                platform {
-                    architecture = 'arm64'
-                    os = 'linux'
-                }
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
         }
     }
     to {

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
@@ -3,6 +3,7 @@ package org.jothika.costoperator;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 
+import org.jothika.costoperator.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,19 +13,22 @@ import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 
 @ControllerConfiguration
 public class CostOptimizationRuleReconciler implements Reconciler<CostOptimizationRule> {
+
     private static final Logger log = LoggerFactory.getLogger(CostOptimizationRuleReconciler.class);
 
     public UpdateControl<CostOptimizationRule> reconcile(
-            CostOptimizationRule primary,
-            Context<CostOptimizationRule> context) {
-        log.info("Reconciling CostOptimizationOperatorCustomResource: {}", primary.getMetadata().getName());
+        CostOptimizationRule primary,
+        Context<CostOptimizationRule> context) {
+        log.info("Reconciling CostOptimizationOperatorCustomResource: {}",
+            primary.getMetadata().getName());
         log.info("Namespace: {}", primary.getMetadata().getNamespace());
         return UpdateControl.noUpdate();
     }
 
     public DeleteControl cleanup(CostOptimizationRule primary,
-                                 Context<CostOptimizationRule> context) {
-        log.info("Cleaning up CostOptimizationOperatorCustomResource: {}", primary.getMetadata().getName());
+        Context<CostOptimizationRule> context) {
+        log.info("Cleaning up CostOptimizationOperatorCustomResource: {}",
+            primary.getMetadata().getName());
         log.info("Namespace: {}", primary.getMetadata().getNamespace());
         return DeleteControl.defaultDelete();
     }

--- a/app/src/main/java/org/jothika/costoperator/Runner.java
+++ b/app/src/main/java/org/jothika/costoperator/Runner.java
@@ -1,8 +1,13 @@
 package org.jothika.costoperator;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.javaoperatorsdk.operator.Operator;
+import org.jothika.costoperator.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 public class Runner {
 
@@ -10,7 +15,20 @@ public class Runner {
 
     public static void main(String[] args) {
         Operator operator = new Operator();
-        log.info("Starting Cost Optimization Operator...");
+        KubernetesClient kubernetesClient = new KubernetesClientBuilder().build();
+        MetricsUtils metricsUtils = new MetricsUtils(kubernetesClient);
+        // Check continuously if the metrics server is installed and available
+        // if installed then start the operator
+        while (!metricsUtils.isMetricsServerAvailable()) {
+            log.info("Metrics server is not installed. Waiting for 5 seconds...");
+            try {
+                TimeUnit.SECONDS.sleep(5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Error while waiting for metrics server", e);
+            }
+        }
+        log.info("Metrics Server is available. Starting Cost Optimization Operator...");
         operator.register(new CostOptimizationRuleReconciler());
         operator.start();
         log.info("Operator started.");

--- a/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
+++ b/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
@@ -1,0 +1,20 @@
+package org.jothika.costoperator.metrics;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetricsUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsUtils.class);
+    private final KubernetesClient kubernetesClient;
+
+    public MetricsUtils(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    public boolean isMetricsServerAvailable() {
+        // Check if the metrics server is available
+        return kubernetesClient.apiServices().withName("v1beta1.metrics.k8s.io").get() != null;
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
+++ b/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
@@ -1,0 +1,50 @@
+package org.jothika.costoperator;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CostOptimizationRuleReconcilerTest {
+
+    @Mock
+    Context<CostOptimizationRule> context;
+
+    //Test reconcile method with mocked context
+    @Test
+    public void testReconcile() {
+        // Create a mock CostOptimizationRule object
+        CostOptimizationRule rule = new CostOptimizationRule();
+        rule.getMetadata().setName("test-rule");
+        rule.getMetadata().setNamespace("test-namespace");
+
+        // Call the reconcile method
+        CostOptimizationRuleReconciler reconciler = new CostOptimizationRuleReconciler();
+        UpdateControl<CostOptimizationRule> updateControl = reconciler.reconcile(rule, context);
+
+        // Verification
+        assertNotNull(updateControl);
+        assertTrue(updateControl.isNoUpdate());
+    }
+
+    //Test cleanup method with mocked context
+    @Test
+    public void testCleanup() {
+        // Create a mock CostOptimizationRule object
+        CostOptimizationRule rule = new CostOptimizationRule();
+        rule.getMetadata().setName("test-rule");
+        rule.getMetadata().setNamespace("test-namespace");
+
+        // Call the cleanup method
+        CostOptimizationRuleReconciler reconciler = new CostOptimizationRuleReconciler();
+        DeleteControl deleteControl = reconciler.cleanup(rule, context);
+
+        // Verification
+        assertNotNull(deleteControl);
+        assertTrue(EqualsBuilder.reflectionEquals(deleteControl, DeleteControl.defaultDelete()));
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
+++ b/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
@@ -1,0 +1,52 @@
+package org.jothika.costoperator.metrics;
+
+import io.fabric8.kubernetes.api.model.APIServiceListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableKubernetesMockClient
+public class MetricsUtilsTest {
+
+    KubernetesMockServer server;
+    private KubernetesClient client;
+
+    @Test
+    @DisplayName("Should return true when metrics server is available")
+    void testServerAvailableSuccess() {
+        // Given
+        server.expect().get()
+            .withPath("/apis/apiregistration.k8s.io/v1/apiservices/v1beta1.metrics.k8s.io")
+            .andReturn(HttpURLConnection.HTTP_OK, new APIServiceListBuilder()
+                .addNewItem()
+                .withNewMetadata().withName("v1beta1.metrics.k8s.io").endMetadata().endItem()
+                .build())
+            .once();
+
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        boolean metricsServerAvailable = metricsUtils.isMetricsServerAvailable();
+
+        // Then
+        assertTrue(metricsServerAvailable);
+    }
+
+    @Test
+    @DisplayName("Should return false when metrics server is unavailable")
+    void testServerAvailableFailure() {
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        boolean metricsServerAvailable = metricsUtils.isMetricsServerAvailable();
+
+        // Then
+        assertFalse(metricsServerAvailable);
+    }
+
+
+}


### PR DESCRIPTION
## Description
This PR introduces a check to ensure the Kubernetes Metrics Server is available before starting the operator's reconcilers. It also adds unit tests and updates build dependencies.

## Changes
#### Startup Logic:
* Loop check for Metrics Server readiness before registering reconcilers in Runner.java.
* Exception handling added for better fault tolerance.

#### Testing:
* `Added MetricsUtilsTest.java`.
* `Added CostOptimizationRuleReconcilerTest.java`.
 #### Build Updates (build.gradle):
* Added `mockitoVersion`.
* Added dependencies:
* `org.mockito:mockito-core`
* `org.mockito:mockito-junit-jupiter`
* `io.fabric8:kubernetes-server-mock`
* Added Jib configuration for container image builds.
* Logging Enhancements in `CostOptimizationRuleReconciler.java`:
* Added namespace logs in reconcile() and cleanup() methods for better traceability.

## Testing
* Verified operator waits until the Metrics Server is available before registering reconcilers.
* Unit tests added for both Metrics utility logic and reconciler functionality.
* Manual test: deployed in a cluster with and without Metrics Server to verify behavior.

## Checklist 
* [ ] I have tested the changes.

 * [ ] I have reviewed the code for syntax errors.

 * [ ] I have checked for any potential security vulnerabilities.
