### PR TITLE
Build and Push Docker Image to DockerHub Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: ./gradlew jib
+        env:
+          _JIB_GRADLE_IMAGE_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          _JIB_GRADLE_IMAGE_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
# Build and Push Docker Image to DockerHub Registry

## Description
This PR introduces changes to build and push a multi-architecture Docker image to DockerHub registry using Gradle Jib. 

## Changes
* Added GitHub Actions workflow for automated Docker image builds
* Configured Jib plugin in build.gradle for Docker image creation
* Implemented multi-architecture support (linux/amd64, linux/arm64)
* Added DockerHub credentials as GitHub secrets
* Configured automatic triggers on merge to main branch

## Related Issues
* Related to #41 

## Testing
### Manual Verification Steps:
1. Merged feature branch into `main` to trigger workflow
2. Verified workflow execution in GitHub Actions tab
3. Confirmed new image appears in DockerHub repository
4. Tested image pull and run on both AMD64 and ARM64 systems:
   ```bash
   docker pull jothikaaravindhan/cost-optimization-operator:latest
   docker run jothikaaravindhan/cost-optimization-operator:latest