### PR TITLE
Add allocated and Usage metrics fetching

### DIFF
--- a/app/crds/costoptimizationrules.org.jothika.costoperator-v1.yml
+++ b/app/crds/costoptimizationrules.org.jothika.costoperator-v1.yml
@@ -12,28 +12,20 @@ spec:
   scope: "Namespaced"
   versions:
   - additionalPrinterColumns:
-    - jsonPath: ".spec.name"
-      name: "NAME"
-      priority: 0
-      type: "string"
-    - jsonPath: ".spec.namespace"
-      name: "NAMESPACE"
-      priority: 0
-      type: "string"
     - jsonPath: ".spec.podName"
-      name: "PODNAME"
+      name: "Pod Name"
       priority: 0
       type: "string"
     - jsonPath: ".spec.resourceType"
-      name: "RESOURCETYPE"
+      name: "Resource Type"
       priority: 0
       type: "string"
     - jsonPath: ".spec.status"
-      name: "STATUS"
+      name: "Status"
       priority: 0
       type: "string"
     - jsonPath: ".spec.threshold"
-      name: "THRESHOLD"
+      name: "Threshold"
       priority: 0
       type: "integer"
     name: "v1"
@@ -42,10 +34,6 @@ spec:
         properties:
           spec:
             properties:
-              name:
-                type: "string"
-              namespace:
-                type: "string"
               notificationEmail:
                 type: "string"
               podName:

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
@@ -1,15 +1,19 @@
 package org.jothika.costoperator;
 
+import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import org.jothika.costoperator.metrics.MetricType;
+import org.jothika.costoperator.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ControllerConfiguration
-public class CostOptimizationRuleReconciler implements Reconciler<CostOptimizationRule> {
+public class CostOptimizationRuleReconciler
+        implements Reconciler<CostOptimizationRule>, Cleaner<CostOptimizationRule> {
 
     private static final Logger log = LoggerFactory.getLogger(CostOptimizationRuleReconciler.class);
 
@@ -19,9 +23,20 @@ public class CostOptimizationRuleReconciler implements Reconciler<CostOptimizati
                 "Reconciling CostOptimizationOperatorCustomResource: {}",
                 primary.getMetadata().getName());
         log.info("Namespace: {}", primary.getMetadata().getNamespace());
+        MetricsUtils metricsUtils = new MetricsUtils(context.getClient());
+        double metricUsagePercentage =
+                metricsUtils.getMetricUsagePercentage(
+                        primary.getMetadata().getNamespace(),
+                        primary.getSpec().getPodName(),
+                        MetricType.fromString(primary.getSpec().getResourceType()));
+        log.info(
+                "Metric({}) usage percentage: {}",
+                primary.getSpec().getResourceType(),
+                metricUsagePercentage);
         return UpdateControl.noUpdate();
     }
 
+    @Override
     public DeleteControl cleanup(
             CostOptimizationRule primary, Context<CostOptimizationRule> context) {
         log.info(

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleSpec.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleSpec.java
@@ -3,30 +3,20 @@ package org.jothika.costoperator;
 import io.fabric8.crd.generator.annotation.PrinterColumn;
 
 public class CostOptimizationRuleSpec {
-    @PrinterColumn private String name;
-    @PrinterColumn private String namespace;
-    @PrinterColumn private String podName;
-    @PrinterColumn private String resourceType;
-    @PrinterColumn private int threshold;
+
+    @PrinterColumn(name = "Pod Name")
+    private String podName;
+
+    @PrinterColumn(name = "Resource Type")
+    private String resourceType;
+
+    @PrinterColumn(name = "Threshold")
+    private int threshold;
+
     private String notificationEmail;
-    @PrinterColumn private String status;
 
-    // Getters and Setters
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getNamespace() {
-        return namespace;
-    }
-
-    public void setNamespace(String namespace) {
-        this.namespace = namespace;
-    }
+    @PrinterColumn(name = "Status")
+    private String status;
 
     public String getPodName() {
         return podName;

--- a/app/src/main/java/org/jothika/costoperator/metrics/MetricType.java
+++ b/app/src/main/java/org/jothika/costoperator/metrics/MetricType.java
@@ -1,0 +1,25 @@
+package org.jothika.costoperator.metrics;
+
+public enum MetricType {
+    CPU("cpu"),
+    MEMORY("memory");
+
+    private final String type;
+
+    MetricType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static MetricType fromString(String type) {
+        for (MetricType metricType : MetricType.values()) {
+            if (metricType.type.equalsIgnoreCase(type)) {
+                return metricType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown metric type: " + type);
+    }
+}

--- a/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
+++ b/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
@@ -25,7 +25,7 @@ public class MetricsUtils {
             String namespace, String podName, MetricType metricType) {
         BigDecimal allocatedMetrics = getAllocatedMetrics(podName, namespace, metricType);
         BigDecimal usageMetrics = getUsageMetrics(podName, namespace, metricType);
-        if (allocatedMetrics.compareTo(BigDecimal.ZERO) == 0) {
+        if (allocatedMetrics.doubleValue() == 0.0) {
             log.warn(
                     "Allocated metrics({}) are zero for pod: {} in namespace: {}",
                     metricType.name(),
@@ -33,7 +33,7 @@ public class MetricsUtils {
                     namespace);
             return 0.0;
         }
-        if (usageMetrics.compareTo(BigDecimal.ZERO) == 0) {
+        if (usageMetrics.doubleValue() == 0.0) {
             log.warn(
                     "Usage metrics({}) are zero for pod: {} in namespace: {}",
                     metricType.name(),
@@ -63,7 +63,7 @@ public class MetricsUtils {
         Pod podToGetMetrics =
                 kubernetesClient.pods().inNamespace(namespace).withName(podName).get();
 
-        if (podToGetMetrics == null) {
+        if (podToGetMetrics.getSpec() == null) {
             log.warn("Pod not found: {} in namespace: {}", podName, namespace);
             return BigDecimal.ZERO;
         }

--- a/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
+++ b/app/src/main/java/org/jothika/costoperator/metrics/MetricsUtils.java
@@ -1,6 +1,9 @@
 package org.jothika.costoperator.metrics;
 
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.math.BigDecimal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,5 +19,103 @@ public class MetricsUtils {
     public boolean isMetricsServerAvailable() {
         // Check if the metrics server is available
         return kubernetesClient.apiServices().withName("v1beta1.metrics.k8s.io").get() != null;
+    }
+
+    public double getMetricUsagePercentage(
+            String namespace, String podName, MetricType metricType) {
+        BigDecimal allocatedMetrics = getAllocatedMetrics(podName, namespace, metricType);
+        BigDecimal usageMetrics = getUsageMetrics(podName, namespace, metricType);
+        if (allocatedMetrics.compareTo(BigDecimal.ZERO) == 0) {
+            log.warn(
+                    "Allocated metrics({}) are zero for pod: {} in namespace: {}",
+                    metricType.name(),
+                    podName,
+                    namespace);
+            return 0.0;
+        }
+        if (usageMetrics.compareTo(BigDecimal.ZERO) == 0) {
+            log.warn(
+                    "Usage metrics({}) are zero for pod: {} in namespace: {}",
+                    metricType.name(),
+                    podName,
+                    namespace);
+            return 0.0;
+        }
+        log.debug(
+                "Usage metrics({}) for pod: {} in namespace: {} is {}",
+                metricType.name(),
+                podName,
+                namespace,
+                usageMetrics.doubleValue());
+        log.debug(
+                "Allocated metrics({}) for pod: {} in namespace: {} is {}",
+                metricType.name(),
+                podName,
+                namespace,
+                allocatedMetrics.doubleValue());
+        // Calculate the percentage
+        return (usageMetrics.doubleValue() / allocatedMetrics.doubleValue()) * 100;
+    }
+
+    private BigDecimal getAllocatedMetrics(
+            String podName, String namespace, MetricType metricType) {
+        log.debug("Fetching allocated metrics for pod: {} in namespace: {}", podName, namespace);
+        Pod podToGetMetrics =
+                kubernetesClient.pods().inNamespace(namespace).withName(podName).get();
+
+        if (podToGetMetrics == null) {
+            log.warn("Pod not found: {} in namespace: {}", podName, namespace);
+            return BigDecimal.ZERO;
+        }
+        return switch (metricType) {
+            case CPU ->
+                    podToGetMetrics.getSpec().getContainers().stream()
+                            .map(
+                                    c ->
+                                            c.getResources()
+                                                    .getRequests()
+                                                    .get("cpu")
+                                                    .getNumericalAmount())
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+            case MEMORY ->
+                    podToGetMetrics.getSpec().getContainers().stream()
+                            .map(
+                                    c ->
+                                            c.getResources()
+                                                    .getRequests()
+                                                    .get("memory")
+                                                    .getNumericalAmount())
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        };
+    }
+
+    private BigDecimal getUsageMetrics(String podName, String namespace, MetricType metricType) {
+        log.debug(
+                "Fetching usage metrics({}) for pod: {} in namespace: {}",
+                metricType.name(),
+                podName,
+                namespace);
+        PodMetrics podMetrics =
+                kubernetesClient.top().pods().inNamespace(namespace).withName(podName).metric();
+
+        if (podMetrics == null || podMetrics.getContainers().isEmpty()) {
+            log.warn(
+                    "No metrics({}) found for pod: {} in namespace: {}",
+                    metricType.name(),
+                    podName,
+                    namespace);
+            return BigDecimal.ZERO;
+        }
+
+        return switch (metricType) {
+            case CPU ->
+                    podMetrics.getContainers().stream()
+                            .map(c -> c.getUsage().get("cpu").getNumericalAmount())
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+            case MEMORY ->
+                    podMetrics.getContainers().stream()
+                            .map(c -> c.getUsage().get("memory").getNumericalAmount())
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        };
     }
 }

--- a/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
+++ b/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
@@ -1,25 +1,55 @@
 package org.jothika.costoperator;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.jothika.costoperator.metrics.MetricType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
+@EnableKubernetesMockClient
 public class CostOptimizationRuleReconcilerTest {
 
     @Mock Context<CostOptimizationRule> context;
 
+    private KubernetesMockServer mockServer;
+    private KubernetesClient mockClient;
+    private TestMockUtils testMockUtils;
+
+    @BeforeEach
+    void setUp() {
+        // Initialize @Mock fields
+        MockitoAnnotations.openMocks(this);
+        // Setup default mock behavior
+        when(context.getClient()).thenReturn(mockClient);
+        // Initialize the mock utils
+        testMockUtils = new TestMockUtils(mockServer);
+    }
+
     // Test reconcile method with mocked context
     @Test
     public void testReconcile() {
-        // Create a mock CostOptimizationRule object
-        CostOptimizationRule rule = new CostOptimizationRule();
-        rule.getMetadata().setName("test-rule");
-        rule.getMetadata().setNamespace("test-namespace");
+        String namespace = "test-namespace";
+        String podName = "test-pod";
+        String ruleName = "test-rule";
+        int threshold = 80;
+
+        // Create a CostOptimizationRule object
+        CostOptimizationRule rule =
+                testMockUtils.getCostOptimizationRule(
+                        ruleName, namespace, podName, MetricType.CPU, threshold);
+        // Mock the kubernetes API endpoints
+        testMockUtils.mockPodAllocatedMetricsK8sApiEndpoints(namespace, podName, "100m", "128Mi");
+        testMockUtils.mockPodUsageMetricsK8sApiEndpoints(namespace, podName, "50m", "64Mi");
 
         // Call the reconcile method
         CostOptimizationRuleReconciler reconciler = new CostOptimizationRuleReconciler();
@@ -37,6 +67,9 @@ public class CostOptimizationRuleReconcilerTest {
         CostOptimizationRule rule = new CostOptimizationRule();
         rule.getMetadata().setName("test-rule");
         rule.getMetadata().setNamespace("test-namespace");
+
+        // Mock the context
+        when(context.getClient()).thenReturn(mockClient);
 
         // Call the cleanup method
         CostOptimizationRuleReconciler reconciler = new CostOptimizationRuleReconciler();

--- a/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
+++ b/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
@@ -107,11 +107,8 @@ public class TestMockUtils {
     }
 
     public void mockPodAllocatedMetricsToNullK8sApiEndpoints(String namespace, String podName) {
-        PodSpec podSpec = new PodSpecBuilder().build();
-
         Pod pod =
                 new PodBuilder()
-                        .withSpec(podSpec)
                         .withMetadata(
                                 new ObjectMetaBuilder()
                                         .withName(podName)

--- a/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
+++ b/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
@@ -1,0 +1,176 @@
+package org.jothika.costoperator;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetricsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+import org.jothika.costoperator.metrics.MetricType;
+
+public class TestMockUtils {
+
+    private final KubernetesMockServer mockServer;
+
+    public TestMockUtils(KubernetesMockServer mockServer) {
+        this.mockServer = mockServer;
+    }
+
+    public CostOptimizationRule getCostOptimizationRule(
+            String ruleName,
+            String namespace,
+            String podName,
+            MetricType resourceType,
+            int threshold) {
+        CostOptimizationRule rule = new CostOptimizationRule();
+        rule.getMetadata().setName(ruleName);
+        rule.getMetadata().setNamespace(namespace);
+        CostOptimizationRuleSpec costOptimizationRuleSpec = new CostOptimizationRuleSpec();
+        costOptimizationRuleSpec.setPodName(podName);
+        costOptimizationRuleSpec.setResourceType(resourceType.name());
+        costOptimizationRuleSpec.setThreshold(threshold);
+        rule.setSpec(costOptimizationRuleSpec);
+        return rule;
+    }
+
+    public void mockPodAllocatedMetricsK8sApiEndpoints(
+            String namespace, String podName, String cpuAllocated, String memoryAllocated) {
+        ResourceRequirements resourceRequirements =
+                new ResourceRequirementsBuilder()
+                        .withRequests(
+                                Map.of(
+                                        MetricType.CPU.getType(),
+                                        new Quantity(cpuAllocated),
+                                        MetricType.MEMORY.getType(),
+                                        new Quantity(memoryAllocated)))
+                        .build();
+        Container container =
+                new ContainerBuilder()
+                        .withName(podName)
+                        .withResources(resourceRequirements)
+                        .build();
+        PodSpec podSpec = new PodSpecBuilder().withContainers(List.of(container)).build();
+
+        Pod pod =
+                new PodBuilder()
+                        .withSpec(podSpec)
+                        .withMetadata(
+                                new ObjectMetaBuilder()
+                                        .withName(podName)
+                                        .withNamespace(namespace)
+                                        .build())
+                        .build();
+
+        mockServer
+                .expect()
+                .get()
+                .withPath(String.format("/api/v1/namespaces/%s/pods/%s", namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, pod)
+                .always();
+    }
+
+    public void mockPodUsageMetricsK8sApiEndpoints(
+            String namespace, String podName, String cpuUsage, String memoryUsage) {
+        ContainerMetrics containerMetrics =
+                new ContainerMetricsBuilder()
+                        .withName(podName)
+                        .withUsage(
+                                Map.of(
+                                        MetricType.CPU.getType(),
+                                        new Quantity(cpuUsage),
+                                        MetricType.MEMORY.getType(),
+                                        new Quantity(memoryUsage)))
+                        .build();
+        PodMetrics podMetrics =
+                new PodMetricsBuilder().withContainers(List.of(containerMetrics)).build();
+        mockServer
+                .expect()
+                .get()
+                .withPath(
+                        String.format(
+                                "/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods/%s",
+                                namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, podMetrics)
+                .always();
+    }
+
+    public void mockPodAllocatedMetricsToNullK8sApiEndpoints(String namespace, String podName) {
+        PodSpec podSpec = new PodSpecBuilder().build();
+
+        Pod pod =
+                new PodBuilder()
+                        .withSpec(podSpec)
+                        .withMetadata(
+                                new ObjectMetaBuilder()
+                                        .withName(podName)
+                                        .withNamespace(namespace)
+                                        .build())
+                        .build();
+
+        mockServer
+                .expect()
+                .get()
+                .withPath(String.format("/api/v1/namespaces/%s/pods/%s", namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, pod)
+                .always();
+    }
+
+    public void mockPodUsageMetricsToNullK8sApiEndpoints(String namespace, String podName) {
+        PodMetrics podMetrics = new PodMetricsBuilder().build();
+        mockServer
+                .expect()
+                .get()
+                .withPath(
+                        String.format(
+                                "/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods/%s",
+                                namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, podMetrics)
+                .always();
+    }
+
+    public void mockPodAllocatedMetricsToEmptyK8sApiEndpoints(String namespace, String podName) {
+        PodSpec podSpec = new PodSpecBuilder().withContainers(List.of()).build();
+
+        Pod pod =
+                new PodBuilder()
+                        .withSpec(podSpec)
+                        .withMetadata(
+                                new ObjectMetaBuilder()
+                                        .withName(podName)
+                                        .withNamespace(namespace)
+                                        .build())
+                        .build();
+
+        mockServer
+                .expect()
+                .get()
+                .withPath(String.format("/api/v1/namespaces/%s/pods/%s", namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, pod)
+                .always();
+    }
+
+    public void mockPodUsageMetricsToEmptyK8sApiEndpoints(String namespace, String podName) {
+        PodMetrics podMetrics = new PodMetricsBuilder().withContainers(List.of()).build();
+        mockServer
+                .expect()
+                .get()
+                .withPath(
+                        String.format(
+                                "/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods/%s",
+                                namespace, podName))
+                .andReturn(HttpURLConnection.HTTP_OK, podMetrics)
+                .always();
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/metrics/MetricTypeTest.java
+++ b/app/src/test/java/org/jothika/costoperator/metrics/MetricTypeTest.java
@@ -1,0 +1,36 @@
+package org.jothika.costoperator.metrics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MetricTypeTest {
+
+    @Test
+    void getType() {
+        MetricType metricType = MetricType.CPU;
+        assertEquals("cpu", metricType.getType());
+        metricType = MetricType.MEMORY;
+        assertEquals("memory", metricType.getType());
+    }
+
+    @Test
+    void fromStringSuccess() {
+        MetricType metricType = MetricType.fromString("memory");
+        assertEquals(MetricType.MEMORY, metricType);
+        metricType = MetricType.fromString("cpu");
+        assertEquals(MetricType.CPU, metricType);
+    }
+
+    @Test
+    void fromStringFailure() {
+        Exception exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            MetricType.fromString("unknown");
+                        });
+        String expectedMessage = "Unknown metric type: unknown";
+        assertTrue(exception.getMessage().contains(expectedMessage));
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
+++ b/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
@@ -7,20 +7,30 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import java.net.HttpURLConnection;
+import org.jothika.costoperator.TestMockUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @EnableKubernetesMockClient
 public class MetricsUtilsTest {
 
-    KubernetesMockServer server;
+    KubernetesMockServer mockServer;
     private KubernetesClient client;
+    private TestMockUtils testMockUtils;
+
+    @BeforeEach
+    void setUp() {
+        // Setup default mock behavior
+        testMockUtils = new TestMockUtils(mockServer);
+    }
 
     @Test
     @DisplayName("Should return true when metrics server is available")
     void testServerAvailableSuccess() {
         // Given
-        server.expect()
+        mockServer
+                .expect()
                 .get()
                 .withPath("/apis/apiregistration.k8s.io/v1/apiservices/v1beta1.metrics.k8s.io")
                 .andReturn(
@@ -51,5 +61,93 @@ public class MetricsUtilsTest {
 
         // Then
         assertFalse(metricsServerAvailable);
+    }
+
+    // Test for metrics success cpu and memory metrics type
+    @Test
+    @DisplayName("Should return usage metrics for CPU and MEMORY")
+    void testGetUsageMetricsSuccess() {
+        // Given
+        String namespace = "default";
+        String podName = "test-pod";
+        testMockUtils.mockPodAllocatedMetricsK8sApiEndpoints(namespace, podName, "100m", "128Mi");
+        testMockUtils.mockPodUsageMetricsK8sApiEndpoints(namespace, podName, "25m", "64Mi");
+
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        double cpuUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.CPU);
+        double memoryUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
+
+        // Then
+        assertEquals(cpuUsageMetricsPercentage, 25.0);
+        assertEquals(memoryUsageMetricsPercentage, 50.0);
+    }
+
+    // Test for metrics failure when pod metrics is null
+    @Test
+    @DisplayName("Should return 0 when pod metrics is null")
+    void testGetMetricsFailureWhenPodMetricsIsNull() {
+        // Given
+        String namespace = "default";
+        String podName = "test-pod";
+        testMockUtils.mockPodUsageMetricsToNullK8sApiEndpoints(namespace, podName);
+        testMockUtils.mockPodAllocatedMetricsToNullK8sApiEndpoints(namespace, podName);
+
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        double cpuUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.CPU);
+        double memoryUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
+
+        // Then
+        assertEquals(cpuUsageMetricsPercentage, 0.0);
+        assertEquals(memoryUsageMetricsPercentage, 0.0);
+    }
+
+    // Test for metrics failure when pod metrics containers is empty
+    @Test
+    @DisplayName("Should return 0 when pod metrics containers is empty")
+    void testGetMetricsFailureWhenPodMetricsContainersIsEmpty() {
+        // Given
+        String namespace = "default";
+        String podName = "test-pod";
+        testMockUtils.mockPodUsageMetricsToEmptyK8sApiEndpoints(namespace, podName);
+        testMockUtils.mockPodAllocatedMetricsToEmptyK8sApiEndpoints(namespace, podName);
+
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        double cpuUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.CPU);
+        double memoryUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
+
+        // Then
+        assertEquals(cpuUsageMetricsPercentage, 0.0);
+        assertEquals(memoryUsageMetricsPercentage, 0.0);
+    }
+
+    // Test for metrics failure when pod usage metrics is null
+    @Test
+    @DisplayName("Should return 0 when pod metrics containers is empty")
+    void testGetMetricsFailureWhenPodUsageMetricsIsNull() {
+        // Given
+        String namespace = "default";
+        String podName = "test-pod";
+        testMockUtils.mockPodUsageMetricsToNullK8sApiEndpoints(namespace, podName);
+        testMockUtils.mockPodAllocatedMetricsK8sApiEndpoints(namespace, podName, "100m", "128Mi");
+
+        // When
+        MetricsUtils metricsUtils = new MetricsUtils(client);
+        double cpuUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.CPU);
+        double memoryUsageMetricsPercentage =
+                metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
+
+        // Then
+        assertEquals(cpuUsageMetricsPercentage, 0.0);
+        assertEquals(memoryUsageMetricsPercentage, 0.0);
     }
 }

--- a/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
+++ b/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
@@ -81,8 +81,8 @@ public class MetricsUtilsTest {
                 metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
 
         // Then
-        assertEquals(cpuUsageMetricsPercentage, 25.0);
-        assertEquals(memoryUsageMetricsPercentage, 50.0);
+        assertEquals(25.0, cpuUsageMetricsPercentage);
+        assertEquals(50.0, memoryUsageMetricsPercentage);
     }
 
     // Test for metrics failure when pod metrics is null
@@ -103,8 +103,8 @@ public class MetricsUtilsTest {
                 metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
 
         // Then
-        assertEquals(cpuUsageMetricsPercentage, 0.0);
-        assertEquals(memoryUsageMetricsPercentage, 0.0);
+        assertEquals(0.0, cpuUsageMetricsPercentage);
+        assertEquals(0.0, memoryUsageMetricsPercentage);
     }
 
     // Test for metrics failure when pod metrics containers is empty
@@ -125,8 +125,8 @@ public class MetricsUtilsTest {
                 metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
 
         // Then
-        assertEquals(cpuUsageMetricsPercentage, 0.0);
-        assertEquals(memoryUsageMetricsPercentage, 0.0);
+        assertEquals(0.0, cpuUsageMetricsPercentage);
+        assertEquals(0.0, memoryUsageMetricsPercentage);
     }
 
     // Test for metrics failure when pod usage metrics is null
@@ -147,7 +147,7 @@ public class MetricsUtilsTest {
                 metricsUtils.getMetricUsagePercentage(namespace, podName, MetricType.MEMORY);
 
         // Then
-        assertEquals(cpuUsageMetricsPercentage, 0.0);
-        assertEquals(memoryUsageMetricsPercentage, 0.0);
+        assertEquals(0.0, cpuUsageMetricsPercentage);
+        assertEquals(0.0, memoryUsageMetricsPercentage);
     }
 }


### PR DESCRIPTION
# Enhanced Kubernetes Metrics Collection

## Description  
This PR introduces comprehensive metrics collection for Kubernetes resources, providing both allocated and usage metrics for CPU and memory with type safety and improved testing infrastructure.

## Changes

### Core Features
- Added allocated/usage metrics collection for:
  - CPU (cores)
  - Memory (bytes)
- Removed redundant `name`/`namespace` from spec (available in parent CR)
- Implemented `MetricType` enum:
  ```java
  public enum MetricType {
    CPU("cores"),
    MEMORY("bytes");
    // ...
  }

## Testing Infrastructure
* Added Kubernetes mock server 
### Mock scenarios include:
* Healthy pod metrics
* Missing metrics server
* Resource threshold violations

## Related Issue 
* #48 

## Checklist (Use/Change where applicable)
* [x] CRD updates apply and tested
* [x] Unit test cases tested
