### PR TITLE
Reconciliation interval added

### DIFF
--- a/app/src/main/java/org/jothika/costoperator/events/EventGenerator.java
+++ b/app/src/main/java/org/jothika/costoperator/events/EventGenerator.java
@@ -1,0 +1,61 @@
+package org.jothika.costoperator.events;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class EventGenerator {
+
+    private final KubernetesClient kubernetesClient;
+
+    public EventGenerator(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    public void generateEvent(
+            HasMetadata resource, String eventName, String message, EventType type)
+            throws KubernetesClientException {
+
+        ObjectReference objectReference =
+                new ObjectReferenceBuilder()
+                        .withApiVersion(resource.getApiVersion())
+                        .withKind(resource.getKind())
+                        .withName(resource.getMetadata().getName())
+                        .withNamespace(resource.getMetadata().getNamespace())
+                        .withUid(resource.getMetadata().getUid())
+                        .build();
+
+        Event event =
+                new EventBuilder()
+                        .withNewMetadata()
+                        .withName(eventName)
+                        .withNamespace(resource.getMetadata().getNamespace())
+                        .endMetadata()
+                        .withInvolvedObject(objectReference)
+                        .withType(type.getType())
+                        .withMessage(message)
+                        .withFirstTimestamp(
+                                DateTimeFormatter.ISO_INSTANT.format(
+                                        ZonedDateTime.now(ZoneOffset.UTC)))
+                        .withLastTimestamp(
+                                DateTimeFormatter.ISO_INSTANT.format(
+                                        ZonedDateTime.now(ZoneOffset.UTC)))
+                        .withNewSource()
+                        .withComponent("cost-optimization-operator")
+                        .endSource()
+                        .build();
+        kubernetesClient
+                .v1()
+                .events()
+                .inNamespace(resource.getMetadata().getNamespace())
+                .resource(event)
+                .create();
+    }
+}

--- a/app/src/main/java/org/jothika/costoperator/events/EventType.java
+++ b/app/src/main/java/org/jothika/costoperator/events/EventType.java
@@ -1,0 +1,25 @@
+package org.jothika.costoperator.events;
+
+public enum EventType {
+    NORMAL("normal"),
+    WARNING("warning");
+
+    private final String type;
+
+    EventType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static EventType fromString(String type) {
+        for (EventType metricType : EventType.values()) {
+            if (metricType.type.equalsIgnoreCase(type)) {
+                return metricType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown event type: " + type);
+    }
+}

--- a/app/src/main/java/org/jothika/costoperator/handlers/RuleHandler.java
+++ b/app/src/main/java/org/jothika/costoperator/handlers/RuleHandler.java
@@ -1,0 +1,47 @@
+package org.jothika.costoperator.handlers;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import java.time.Instant;
+import org.jothika.costoperator.CostOptimizationRule;
+import org.jothika.costoperator.events.EventGenerator;
+import org.jothika.costoperator.events.EventType;
+import org.jothika.costoperator.metrics.MetricType;
+import org.jothika.costoperator.metrics.MetricsUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RuleHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(RuleHandler.class);
+    CostOptimizationRule costOptimizationRule;
+    KubernetesClient kubernetesClient;
+    EventGenerator eventGenerator;
+    MetricsUtils metricsUtils;
+
+    public RuleHandler(
+            CostOptimizationRule costOptimizationRule, KubernetesClient kubernetesClient) {
+        this.costOptimizationRule = costOptimizationRule;
+        this.kubernetesClient = kubernetesClient;
+        this.eventGenerator = new EventGenerator(kubernetesClient);
+        this.metricsUtils = new MetricsUtils(kubernetesClient);
+    }
+
+    public void reconcileRule() {
+        Instant reconciliationStartTime = Instant.now();
+        double metricUsagePercentage =
+                metricsUtils.getMetricUsagePercentage(
+                        costOptimizationRule.getMetadata().getNamespace(),
+                        costOptimizationRule.getSpec().getPodName(),
+                        MetricType.fromString(costOptimizationRule.getSpec().getResourceType()));
+        String message =
+                String.format(
+                        "Metric(%s) usage percentage: %s",
+                        costOptimizationRule.getSpec().getResourceType(), metricUsagePercentage);
+        log.info(message);
+        eventGenerator.generateEvent(
+                costOptimizationRule,
+                "Reconciliation at " + reconciliationStartTime,
+                message,
+                EventType.NORMAL);
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
+++ b/app/src/test/java/org/jothika/costoperator/CostOptimizationRuleReconcilerTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @EnableKubernetesMockClient
-public class CostOptimizationRuleReconcilerTest {
+class CostOptimizationRuleReconcilerTest {
 
     @Mock Context<CostOptimizationRule> context;
 
@@ -37,7 +37,7 @@ public class CostOptimizationRuleReconcilerTest {
 
     // Test reconcile method with mocked context
     @Test
-    public void testReconcile() {
+    void testReconcile() {
         String namespace = "test-namespace";
         String podName = "test-pod";
         String ruleName = "test-rule";
@@ -50,6 +50,7 @@ public class CostOptimizationRuleReconcilerTest {
         // Mock the kubernetes API endpoints
         testMockUtils.mockPodAllocatedMetricsK8sApiEndpoints(namespace, podName, "100m", "128Mi");
         testMockUtils.mockPodUsageMetricsK8sApiEndpoints(namespace, podName, "50m", "64Mi");
+        testMockUtils.mockEventsApiToEmptyResponse(namespace);
 
         // Call the reconcile method
         CostOptimizationRuleReconciler reconciler = new CostOptimizationRuleReconciler();
@@ -62,7 +63,7 @@ public class CostOptimizationRuleReconcilerTest {
 
     // Test cleanup method with mocked context
     @Test
-    public void testCleanup() {
+    void testCleanup() {
         // Create a mock CostOptimizationRule object
         CostOptimizationRule rule = new CostOptimizationRule();
         rule.getMetadata().setName("test-rule");

--- a/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
+++ b/app/src/test/java/org/jothika/costoperator/TestMockUtils.java
@@ -170,4 +170,13 @@ public class TestMockUtils {
                 .andReturn(HttpURLConnection.HTTP_OK, podMetrics)
                 .always();
     }
+
+    public void mockEventsApiToEmptyResponse(String namespace) {
+        mockServer
+                .expect()
+                .post()
+                .withPath(String.format("/api/v1/namespaces/%s/events", namespace))
+                .andReturn(HttpURLConnection.HTTP_OK, "{}")
+                .once();
+    }
 }

--- a/app/src/test/java/org/jothika/costoperator/events/EventGeneratorTest.java
+++ b/app/src/test/java/org/jothika/costoperator/events/EventGeneratorTest.java
@@ -1,0 +1,96 @@
+package org.jothika.costoperator.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import java.net.HttpURLConnection;
+import org.jothika.costoperator.CostOptimizationRule;
+import org.jothika.costoperator.TestMockUtils;
+import org.jothika.costoperator.metrics.MetricType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@EnableKubernetesMockClient
+class EventGeneratorTest {
+
+    KubernetesMockServer mockServer;
+    private KubernetesClient client;
+    TestMockUtils testMockUtils;
+
+    @BeforeEach
+    void setUp() {
+        // Setup default mock behavior
+        testMockUtils = new TestMockUtils(mockServer);
+    }
+
+    @Test
+    void generateEvent() throws InterruptedException, JsonProcessingException {
+        // Given
+        String namespace = "test-namespace";
+        String podName = "test-pod";
+        String message = "Test event message";
+        EventType eventType = EventType.NORMAL;
+
+        CostOptimizationRule rule =
+                testMockUtils.getCostOptimizationRule(
+                        "sample-rule", namespace, podName, MetricType.CPU, 30);
+        testMockUtils.mockEventsApiToEmptyResponse(namespace);
+
+        // When
+        EventGenerator eventGenerator = new EventGenerator(client);
+        eventGenerator.generateEvent(rule, podName, message, eventType);
+
+        // Then
+        ObjectMapper objectMapper = new ObjectMapper();
+        Event event =
+                objectMapper.readValue(
+                        mockServer.getLastRequest().getBody().readUtf8(), Event.class);
+
+        assertEquals(rule.getMetadata().getName(), event.getInvolvedObject().getName());
+        assertEquals(rule.getMetadata().getNamespace(), event.getInvolvedObject().getNamespace());
+        assertEquals(rule.getMetadata().getUid(), event.getInvolvedObject().getUid());
+        assertEquals(rule.getApiVersion(), event.getInvolvedObject().getApiVersion());
+        assertEquals(rule.getKind(), event.getInvolvedObject().getKind());
+        assertEquals(eventType.getType(), event.getType());
+        assertEquals(message, event.getMessage());
+    }
+
+    @Test
+    void generateEventFailure() {
+        // Given
+        String namespace = "test-namespace";
+        String podName = "test-pod";
+        String message = "Test event message";
+        EventType eventType = EventType.NORMAL;
+
+        CostOptimizationRule rule =
+                testMockUtils.getCostOptimizationRule(
+                        "sample-rule", namespace, podName, MetricType.CPU, 30);
+
+        mockServer
+                .expect()
+                .post()
+                .withPath(String.format("/api/v1/namespaces/%s/events", namespace))
+                .andReturn(HttpURLConnection.HTTP_NOT_FOUND, "{}")
+                .once();
+
+        // When
+        EventGenerator eventGenerator = new EventGenerator(client);
+
+        // Then
+        Exception exception =
+                assertThrows(
+                        KubernetesClientException.class,
+                        () -> {
+                            eventGenerator.generateEvent(rule, podName, message, eventType);
+                        });
+        String expectedMessage = "Failure executing: POST";
+        assertTrue(exception.getMessage().contains(expectedMessage));
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/events/EventTypeTest.java
+++ b/app/src/test/java/org/jothika/costoperator/events/EventTypeTest.java
@@ -1,0 +1,36 @@
+package org.jothika.costoperator.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class EventTypeTest {
+
+    @Test
+    void getType() {
+        EventType eventType = EventType.NORMAL;
+        assertEquals("normal", eventType.getType());
+        eventType = EventType.WARNING;
+        assertEquals("warning", eventType.getType());
+    }
+
+    @Test
+    void fromStringSuccess() {
+        EventType eventType = EventType.fromString("normal");
+        assertEquals(EventType.NORMAL, eventType);
+        eventType = EventType.fromString("warning");
+        assertEquals(EventType.WARNING, eventType);
+    }
+
+    @Test
+    void fromStringFailure() {
+        Exception exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            EventType.fromString("unknown");
+                        });
+        String expectedMessage = "Unknown event type: unknown";
+        assertTrue(exception.getMessage().contains(expectedMessage));
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/handlers/RuleHandlerTest.java
+++ b/app/src/test/java/org/jothika/costoperator/handlers/RuleHandlerTest.java
@@ -1,0 +1,68 @@
+package org.jothika.costoperator.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.jothika.costoperator.CostOptimizationRule;
+import org.jothika.costoperator.TestMockUtils;
+import org.jothika.costoperator.events.EventType;
+import org.jothika.costoperator.metrics.MetricType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@EnableKubernetesMockClient
+class RuleHandlerTest {
+
+    TestMockUtils testMockUtils;
+    private KubernetesMockServer mockServer;
+    private KubernetesClient mockClient;
+
+    @BeforeEach
+    void setUp() {
+        // Setup default mock behavior
+        testMockUtils = new TestMockUtils(mockServer);
+    }
+
+    // test reconcile rule success
+    @ParameterizedTest
+    @EnumSource(MetricType.class)
+    void testReconcileRuleSuccess(MetricType metricType)
+            throws InterruptedException, JsonProcessingException {
+        String namespace = "test-namespace";
+        String podName = "test-pod";
+        // Create a mock CostOptimizationRule object
+        CostOptimizationRule rule =
+                testMockUtils.getCostOptimizationRule(
+                        "test-rule", namespace, podName, metricType, 80);
+        testMockUtils.mockPodAllocatedMetricsK8sApiEndpoints(namespace, podName, "100m", "128Mi");
+        testMockUtils.mockPodUsageMetricsK8sApiEndpoints(namespace, podName, "50m", "64Mi");
+        testMockUtils.mockEventsApiToEmptyResponse(namespace);
+        // Create a RuleHandler object
+        RuleHandler ruleHandler = new RuleHandler(rule, mockClient);
+
+        // Call the reconcile method
+        ruleHandler.reconcileRule();
+
+        // Verify the result
+        ObjectMapper objectMapper = new ObjectMapper();
+        Event event =
+                objectMapper.readValue(
+                        mockServer.getLastRequest().getBody().readUtf8(), Event.class);
+
+        assertEquals(rule.getMetadata().getName(), event.getInvolvedObject().getName());
+        assertEquals(rule.getMetadata().getNamespace(), event.getInvolvedObject().getNamespace());
+        assertEquals(rule.getMetadata().getUid(), event.getInvolvedObject().getUid());
+        assertEquals(rule.getApiVersion(), event.getInvolvedObject().getApiVersion());
+        assertEquals(rule.getKind(), event.getInvolvedObject().getKind());
+        assertEquals(EventType.NORMAL.getType(), event.getType());
+        assertEquals(
+                "Metric(" + metricType.getType().toUpperCase() + ") usage percentage: 50.0",
+                event.getMessage());
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
+++ b/app/src/test/java/org/jothika/costoperator/metrics/MetricsUtilsTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @EnableKubernetesMockClient
-public class MetricsUtilsTest {
+class MetricsUtilsTest {
 
     KubernetesMockServer mockServer;
     private KubernetesClient client;


### PR DESCRIPTION


## Description
This pull request introduces a reconciliation interval mechanism and adds support for generating rule-related events. The reconciliation process is now driven by a configurable interval. Additionally, a new event system has been implemented to emit events upon the completion of a reconciliation, attaching the event to the relevant Rule CR. Unit tests have also been added to ensure proper functionality.

## Changes
* Added reconciliation interval support to `CostOptimizationRuleReconciler`
* Introduced new event generation system:
  * Added `EventGenerator.java`
  * Added `EventType.java`
* New handler introduced:
  * Added `RuleHandler.java`
* Modified the following files to integrate the new functionality:
  * `CostOptimizationRuleReconciler.java`: Added support for reconciliation interval and event trigger
  * `CostOptimizationRuleReconcilerTest.java`: Added unit tests for reconciliation logic
  * `TestMockUtils.java`: Added new helper methods for testing
  * `EventGeneratorTest.java`: Unit tests for event generation
  * `EventTypeTest.java`: Unit tests for event type enum
  * `RuleHandlerTest.java`: Unit tests for rule handler
  * `MetricsUtilsTest.java`: Added test improvements related to metrics

## Related Issues
* #48 

## Testing
* All new functionalities are covered with unit tests.
* Verified that the reconciliation interval is respected.
* Confirmed that events are generated and attached to Rule CRs correctly.

## Checklist (Use/Change where applicable)
* [x] I have tested the changes.
* [x] I have reviewed the code for syntax errors.
* [x] I have checked for any potential security vulnerabilities.
