### PR TITLE
Introduce rule status

### DIFF
--- a/app/crds/costoptimizationrules.org.jothika.costoperator-v1.yml
+++ b/app/crds/costoptimizationrules.org.jothika.costoperator-v1.yml
@@ -20,14 +20,14 @@ spec:
       name: "Resource Type"
       priority: 0
       type: "string"
-    - jsonPath: ".spec.status"
-      name: "Status"
-      priority: 0
-      type: "string"
     - jsonPath: ".spec.threshold"
       name: "Threshold"
       priority: 0
       type: "integer"
+    - jsonPath: ".status.ruleStatus"
+      name: "Status"
+      priority: 0
+      type: "string"
     name: "v1"
     schema:
       openAPIV3Schema:
@@ -40,12 +40,13 @@ spec:
                 type: "string"
               resourceType:
                 type: "string"
-              status:
-                type: "string"
               threshold:
                 type: "integer"
             type: "object"
           status:
+            properties:
+              ruleStatus:
+                type: "string"
             type: "object"
         type: "object"
     served: true

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleReconciler.java
@@ -33,8 +33,7 @@ public class CostOptimizationRuleReconciler
                 "Reconciling {}.{}",
                 primary.getMetadata().getNamespace(),
                 primary.getMetadata().getName());
-        ruleHandler.reconcileRule(primary);
-        return UpdateControl.patchStatus(primary);
+        return UpdateControl.patchStatus(ruleHandler.reconcileRule(primary));
     }
 
     @Override

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleSpec.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleSpec.java
@@ -15,9 +15,6 @@ public class CostOptimizationRuleSpec {
 
     private String notificationEmail;
 
-    @PrinterColumn(name = "Status")
-    private String status;
-
     public String getPodName() {
         return podName;
     }
@@ -48,13 +45,5 @@ public class CostOptimizationRuleSpec {
 
     public void setNotificationEmail(String notificationEmail) {
         this.notificationEmail = notificationEmail;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
     }
 }

--- a/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleStatus.java
+++ b/app/src/main/java/org/jothika/costoperator/CostOptimizationRuleStatus.java
@@ -1,3 +1,18 @@
 package org.jothika.costoperator;
 
-public class CostOptimizationRuleStatus {}
+import io.fabric8.crd.generator.annotation.PrinterColumn;
+
+public class CostOptimizationRuleStatus {
+
+    @PrinterColumn(name = "Status")
+    private String ruleStatus;
+
+    // getter and setter for ruleStatus
+    public String getRuleStatus() {
+        return ruleStatus;
+    }
+
+    public void setRuleStatus(String ruleStatus) {
+        this.ruleStatus = ruleStatus;
+    }
+}

--- a/app/src/main/java/org/jothika/costoperator/RuleStatus.java
+++ b/app/src/main/java/org/jothika/costoperator/RuleStatus.java
@@ -1,0 +1,26 @@
+package org.jothika.costoperator;
+
+public enum RuleStatus {
+    CREATED("Created"),
+    ACTIVE("Active"),
+    COMPLETED("Completed");
+
+    private final String status;
+
+    RuleStatus(String status) {
+        this.status = status;
+    }
+
+    public static RuleStatus fromString(String status) {
+        for (RuleStatus ruleStatusType : RuleStatus.values()) {
+            if (ruleStatusType.status.equalsIgnoreCase(status)) {
+                return ruleStatusType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown rule status: " + status);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/RuleStatusTest.java
+++ b/app/src/test/java/org/jothika/costoperator/RuleStatusTest.java
@@ -1,0 +1,42 @@
+package org.jothika.costoperator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RuleStatusTest {
+
+    @Test
+    void getType() {
+        RuleStatus ruleStatus = RuleStatus.ACTIVE;
+        assertEquals("Active", ruleStatus.getStatus());
+        ruleStatus = RuleStatus.CREATED;
+        assertEquals("Created", ruleStatus.getStatus());
+        ruleStatus = RuleStatus.COMPLETED;
+        assertEquals("Completed", ruleStatus.getStatus());
+    }
+
+    @Test
+    void fromStringSuccess() {
+        RuleStatus ruleStatus = RuleStatus.fromString("Created");
+        assertEquals(RuleStatus.CREATED, ruleStatus);
+        ruleStatus = RuleStatus.fromString("Active");
+        assertEquals(RuleStatus.ACTIVE, ruleStatus);
+        ruleStatus = RuleStatus.fromString("Completed");
+        assertEquals(RuleStatus.COMPLETED, ruleStatus);
+    }
+
+    @Test
+    void fromStringFailure() {
+        Exception exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            RuleStatus.fromString("unknown");
+                        });
+        String expectedMessage = "Unknown rule status: unknown";
+        assertTrue(exception.getMessage().contains(expectedMessage));
+    }
+}

--- a/app/src/test/java/org/jothika/costoperator/handlers/RuleHandlerTest.java
+++ b/app/src/test/java/org/jothika/costoperator/handlers/RuleHandlerTest.java
@@ -1,5 +1,6 @@
 package org.jothika.costoperator.handlers;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,6 +10,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.jothika.costoperator.CostOptimizationRule;
+import org.jothika.costoperator.CostOptimizationRuleStatus;
 import org.jothika.costoperator.TestMockUtils;
 import org.jothika.costoperator.events.EventGenerator;
 import org.jothika.costoperator.events.EventType;
@@ -111,5 +113,23 @@ class RuleHandlerTest {
         assertEquals(rule.getApiVersion(), event.getInvolvedObject().getApiVersion());
         assertEquals(rule.getKind(), event.getInvolvedObject().getKind());
         assertEquals(EventType.NORMAL.getType(), event.getType());
+    }
+
+    @ParameterizedTest
+    @EnumSource(MetricType.class)
+    void testReconcileRuleCompletedState(MetricType metricType) {
+        String namespace = "test-namespace";
+        String podName = "test-pod";
+        // Create a mock CostOptimizationRule object
+        CostOptimizationRule rule =
+                testMockUtils.getCostOptimizationRule(
+                        "test-rule", namespace, podName, metricType, 20);
+
+        CostOptimizationRuleStatus status = new CostOptimizationRuleStatus();
+        status.setRuleStatus("Completed");
+        rule.setStatus(status);
+
+        // Call the reconcile method
+        assertDoesNotThrow(() -> ruleHandler.reconcileRule(rule));
     }
 }


### PR DESCRIPTION

## Description
Added rule status tracking to manage the lifecycle of rules from creation to completion. The status transitions from `CREATED` to `ACTIVE` during processing, and finally to `COMPLETED` once the rule condition is satisfied and the notification is sent. Completed rules are no longer reconciled.

## Changes
* Introduced rule status tracking with states: `CREATED`, `ACTIVE`, and `COMPLETED`.
* Default status set to `CREATED` when a rule is created.
* Status transitions to `ACTIVE` when reconciler starts processing.
* Status moves to `COMPLETED` after rule condition is met and notification is sent.
* `COMPLETED` rules are excluded from further reconciliation.
* `ACTIVE` rules are continuously reconciled for resource updates.

## Related Issues
* #50 

## Testing
* Verified status transitions (`CREATED` → `ACTIVE` → `COMPLETED`) via unit tests.
* Confirmed `COMPLETED` rules are not reprocessed during reconciliation.
* Validated continuous reconciliation for `ACTIVE` rules.

## Checklist (Use/Change where applicable)
* [x] I have tested the changes.
* [x] I have reviewed the code for syntax errors.
* [x] I have checked for any potential security vulnerabilities.