### PR TITLE
Revert github container registry image push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,35 +38,3 @@ jobs:
         env:
           _JIB_GRADLE_IMAGE_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           _JIB_GRADLE_IMAGE_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-
-  build-and-push-github-container-registry:
-    runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Login to Github container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image to Github container registry
-        run: ./gradlew jib
-        env:
-          _JIB_GRADLE_IMAGE_USERNAME: ${{ github.actor }}
-          _JIB_GRADLE_IMAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description  
This PR reverts the GitHub Container Registry (GHCR) image push changes introduced in [#PR_NUMBER], maintaining only Docker Hub publishing.  

## Changes  
* **Removed GHCR publishing**:  
  - Deleted GHCR-specific steps from CI workflow.  
  - Removed GHCR authentication (`GITHUB_TOKEN` usage).  
* **Retained Docker Hub push**:  
  - Kept existing Docker Hub build/push logic.  
* **Cleanup**:  
  - Removed GHCR-related image tags and documentation references.  

## Related Issues  
* Reverts #93 
* Connected to #56 

## Testing  
* **CI Workflow**:  
  - Confirmed Docker Hub push succeeds.  
  - Verified GHCR push is **skipped** in logs.  
* **Image Validation**:  
  - Docker Hub image pulls successfully (`docker pull your-org/image:latest`).  
  - GHCR image no longer updates (validated via [GHCR UI](https://ghcr.io)).  

## Checklist  
* [x] Docker Hub push remains functional.  
* [x] GHCR references removed from workflow/docs.  
* [x] SonarQube scan passes 