### PR TITLE
Azure VM cleanup added in deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-azure-vm.yml
+++ b/.github/workflows/deploy-to-azure-vm.yml
@@ -15,7 +15,7 @@ on:
           - Staging
           - Production
       imageTag:
-        description: Docker image tag (e.g. 1.2.3-SNAPSHOT)
+        description: Docker image tag (e.g. 0.2.0-SNAPSHOT)
         required: true
 
 jobs:
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Set up SSH
+      - name: Set up SSH for Azure VM
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.AZURE_VM_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.AZURE_VM_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Wait for SSH to become available
+      - name: Wait for Azure VM SSH to become available
         run: |
           for i in {1..20}; do
             if ssh -o StrictHostKeyChecking=no ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} "echo VM is up"; then
@@ -45,26 +45,35 @@ jobs:
             sleep 15
           done
 
-      - name: Clean up Kubernetes environment
+      - name: Clean up Azure VM Kubernetes environment
         run: |
-          ssh ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << 'EOF'
-            set -e
+          set -e
+          ssh -o StrictHostKeyChecking=no ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << 'EOF'
             helm uninstall ${{ secrets.HELM_RELEASE_NAME }} || true
+            kubectl delete -f costoptimizationrules.org.jothika.costoperator-v1.yml || true
+            rm costoptimizationrules.org.jothika.costoperator-v1.yml || true
+            rm -r charts || true
           EOF
 
-      - name: Deploy Helm chart
+      - name: Copy Helm chart to Azure VM
         run: |
-          ssh ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << EOF
-            set -e
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa -r ./charts ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }}:/home/${{ secrets.AZURE_VM_USERNAME }}/charts
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa -r ./app/crds/costoptimizationrules.org.jothika.costoperator-v1.yml ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }}:/home/${{ secrets.AZURE_VM_USERNAME }}/costoptimizationrules.org.jothika.costoperator-v1.yml
+
+      - name: Deploy Helm chart to Azure VM
+        run: |
+          set -e
+          ssh -o StrictHostKeyChecking=no ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << 'EOF'
+            kubectl apply -f costoptimizationrules.org.jothika.costoperator-v1.yml
             cd charts/cost-optimization-operator
-            helm upgrade --install ${{ secrets.HELM_RELEASE_NAME }} . \
+            helm upgrade --debug --install ${{ secrets.HELM_RELEASE_NAME }} . \
               --set image.tag=${{ github.event.inputs.imageTag }} \
               --wait --timeout 300s
           EOF
 
-      - name: Check Helm deployment status
+      - name: Check Helm deployment status on Azure VM
         run: |
-          ssh ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << 'EOF'
+          ssh -o StrictHostKeyChecking=no ${{ secrets.AZURE_VM_USERNAME }}@${{ secrets.AZURE_VM_HOST }} << 'EOF'
             status=$(helm status ${{ secrets.HELM_RELEASE_NAME }} -o json | jq -r .info.status)
             echo "Helm status: $status"
             if [ "$status" != "deployed" ]; then


### PR DESCRIPTION
## Description  
This pull request adds logic to the CD deployment GitHub Actions workflow for automating the cleanup and deployment process on the Azure VM. The updated workflow ensures a clean Kubernetes environment before deploying the latest Helm charts, followed by deployment status validation.

## Changes  
* Added Azure VM cleanup step before deployment:
  - Uninstalled existing Helm releases
* Deployed Helm chart with dynamic image tag from workflow input
* Verified Helm deployment status to determine success/failure of the CD job
* Ensured workflow fails fast if Helm deployment is not successful

## Related Issues  
* #114  

## Testing  
* Workflow manually triggered with test image versions and confirmed successful end-to-end deployment
* Verified:
  - Azure VM started and accessible via SSH
  - Environment cleaned up before install
  - Helm chart deployed with correct image tag
  - Helm deployment status returned as "deployed"
  - Workflow succeeded only if all steps passed

## Checklist  
* [x] I have tested the changes.  
* [x] I have reviewed the code for syntax errors.  
* [x] I have checked for any potential security vulnerabilities.
