### PR TITLE
Testing Deployment should trigger on completion of building the image

### DIFF
--- a/.github/workflows/trigger-testing-azure-deployment.yml
+++ b/.github/workflows/trigger-testing-azure-deployment.yml
@@ -1,9 +1,10 @@
 name: Deploy to Azure Testing Environment
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build and Push Docker Image"]
+    types:
+      - completed
 
 permissions:
   contents: write  # Required for gh CLI to trigger workflows
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   trigger-testing-azure-deployment:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
This pull request modifies the CI/CD pipeline configuration to ensure that testing deployments are automatically triggered upon successful completion of the image-building step.

## Changes
* Updated CI/CD pipeline configuration (e.g., GitHub Actions)
* Added a job dependency to initiate testing deployment post image build


## Related Issues
* Closes #71  – Trigger testing deployment after image build

## Testing
* Validated pipeline in a staging environment
* Monitored workflow runs to confirm testing deployment triggers as expected
* Verified proper job dependency and exit codes

## Checklist
* [x] I have tested the changes.
* [x] I have reviewed the code for syntax errors.
* [x] I have checked for any potential security vulnerabilities.
* [x] I have validated that the testing deployment triggers after image build completion.
