### PR TITLE
Upgrade Gradle, Spring Boot, Java operator SDK versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ plugins {
     id("jacoco")
     id("com.google.cloud.tools.jib") version "3.4.5"
     id("com.diffplug.spotless") version "7.0.3"
-    id("org.sonarqube") version "6.1.0.5360"
-    id("org.springframework.boot") version "3.4.5"
+    id("org.sonarqube") version "6.2.0.5505"
+    id("org.springframework.boot") version "3.5.0"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -22,12 +22,12 @@ version = "0.2.0-SNAPSHOT"
 
 ext {
     javaVersion = JavaVersion.VERSION_21
-    josdkVersion = "5.0.4"
+    josdkVersion = "5.1.0"
     slf4jVersion = "1.7.36"
     log4jVersion = "2.20.0"
     junitVersion = "5.9.2"
-    fabric8Version = "7.1.0"
-    mockitoVersion = "5.17.0"
+    fabric8Version = "7.3.1"
+    mockitoVersion = "5.18.0"
     mailApiVersion = "2.1.3"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
This pull request upgrades key dependencies in the `build.gradle` file to ensure compatibility with newer features, performance improvements, and security patches.

## Changes
* Upgraded **Gradle** version to `8.14.1`
* Upgraded **Spring Boot** version to `3.5.0`
* Upgraded **Java Operator SDK** version to `5.1.0`
* Added `fabric8Version = "7.3.1"` for Kubernetes client support
* Added `mockitoVersion = "5.18.0"` for enhanced mocking in unit tests

## Testing
* Verified the build runs successfully with the upgraded versions
* Ran application locally to ensure it starts and works as expected
* Confirmed no breaking changes introduced in the SDK upgrade

## Checklist
* [x] I have tested the changes.
* [x] I have reviewed the code for syntax errors.
* [x] I have checked for any potential security vulnerabilities.
* [x] I have confirmed compatibility with upgraded dependencies.
