### PR TITLE
Trivy docker image scan added

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,3 +40,27 @@ jobs:
         env:
           _JIB_GRADLE_IMAGE_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           _JIB_GRADLE_IMAGE_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version from build.gradle
+        id: get_version
+        run: |
+          VERSION=$(grep '^version\s*=' app/build.gradle | sed 's/version\s*=\s*["'\'']\([^"'\'']*\)["'\'']/\1/')
+          echo "Detected version: $VERSION"
+          echo "image_tag=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/jothikaaravindhan/cost-optimization-operator:${{ steps.get_version.outputs.image_tag }}'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Description
This PR adds a Trivy security scan step to the CI pipeline that scans the built Docker image after it is pushed to Docker Hub. The scan results are integrated with GitHub’s **Security > Code scanning alerts** to highlight any **CRITICAL** or **HIGH** vulnerabilities.

## Changes
* Added a new step in the CI workflow to run `trivy image` scan on the pushed Docker image
* Configured Trivy to output results in SARIF format
* Uploaded SARIF results to GitHub for visibility under the **Code Scanning** tab

## Related Issues
* Security hardening
* Visibility of Docker image vulnerabilities in GitHub UI

## Testing
* Verified the scan runs successfully after Docker push
* Confirmed SARIF report is generated and uploaded
* Validated appearance of scan alerts under GitHub > Security > Code scanning

## Checklist
* [x] I have tested the changes.
* [x] I have reviewed the workflow for syntax and logic errors.
* [x] I have confirmed vulnerabilities are surfaced in GitHub's security tab.
* [x] I have ensured the Trivy scan runs after every image push.
