### PR TITLE
Sample CR for Demo added

### DIFF
--- a/User-Guide.md
+++ b/User-Guide.md
@@ -61,7 +61,7 @@ helm install cost-optimization-operator charts/cost-optimization-operator
 ```
 ### 6. Deploy Custom Resource (CR)
 ```bash
-kubectl apply -f app/crds/my-first-cr.yaml -n cost-optimization
+kubectl apply -f app/crds/nginx-cpu-greater-than-point-one-cr.yaml -n cost-optimization
 ```
 Make sure to update the namespace, threshold, and resource type inside the CR YAML.
 

--- a/app/crds/invalid-pod-name-cr.yml
+++ b/app/crds/invalid-pod-name-cr.yml
@@ -1,0 +1,13 @@
+apiVersion: org.jothika.costoperator/v1
+kind: CostOptimizationRule
+metadata:
+  name: invalid-pod-name-cr
+  namespace: default
+spec:
+  notificationEmail: apitest4@gmail.com
+  podName: nginxasd
+  resourceType: memory
+  thresholdCondition: GREATERTHAN
+  threshold: 0.1
+
+

--- a/app/crds/nginx-cpu-greater-than-point-one-cr.yaml
+++ b/app/crds/nginx-cpu-greater-than-point-one-cr.yaml
@@ -1,0 +1,11 @@
+apiVersion: org.jothika.costoperator/v1
+kind: CostOptimizationRule
+metadata:
+  name: nginx-cpu-greater-than-point-one
+  namespace: default
+spec:
+  notificationEmail: apitest4@gmail.com
+  podName: nginx-release-54bb959bd7-p7c69
+  resourceType: CPU
+  thresholdCondition: GREATERTHAN
+  threshold: 0.1

--- a/app/crds/nginx-cpu-less-than-point-one-cr.yaml
+++ b/app/crds/nginx-cpu-less-than-point-one-cr.yaml
@@ -1,11 +1,11 @@
 apiVersion: org.jothika.costoperator/v1
 kind: CostOptimizationRule
 metadata:
-  name: nginx-cpu
+  name: nginx-cpu-less-than-point-one
   namespace: default
 spec:
   notificationEmail: apitest4@gmail.com
   podName: nginx-release-54bb959bd7-p7c69
   resourceType: CPU
-  thresholdCondition: GREATERTHAN
+  thresholdCondition: LESSTHAN
   threshold: 0.1


### PR DESCRIPTION
## Description
This PR adds a sample Custom Resource (CR) YAML file to the repository. It serves as a demo to showcase how the custom resource definition (CRD) can be used and tested in a Kubernetes environment.

## Changes
* Added `sample-cr.yaml` containing a demo CR instance
* Provides a reference for users and developers to create their own CRs
* Ensures the CR structure aligns with the deployed CRD

## Related Issues
* Useful for onboarding, documentation, or demo environments
* May assist in validating CRD changes

## Testing
* Applied the CR in a local Kubernetes cluster to verify schema compatibility
* Confirmed that the controller/operator processes the CR as expected

## Checklist
* [x] I have tested the sample CR with a running operator.
* [x] I have validated the CR structure against the CRD.
* [x] I have documented the sample or placed it in an appropriate directory
