### PR TITLE
Workflow added for CD for environment Staging and Production

### DIFF
--- a/.github/workflows/trigger-release-azure-deployment.yml
+++ b/.github/workflows/trigger-release-azure-deployment.yml
@@ -1,0 +1,58 @@
+name: Deploy to Azure Staging and Production
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write  # Required for gh CLI to trigger workflows
+  actions: write   # Recommended if triggering other workflows
+
+jobs:
+  deploy-if-release:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Extract version from build.gradle
+        id: get_version
+        run: |
+          VERSION=$(grep '^version\s*=' app/build.gradle | sed 's/version\s*=\s*["'\'']\([^"'\'']*\)["'\'']/\1/')
+          CLEAN_VERSION=$(echo "$VERSION" | sed 's/-SNAPSHOT//')
+          echo "Full version: $VERSION"
+          echo "Release version: $CLEAN_VERSION"
+          echo "image_tag=$CLEAN_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger Testing Deployment
+        run: |
+          gh workflow run deploy-to-azure-vm.yml \
+            --ref "main" \
+            -f environment=Production \
+            -f imageTag=${{ steps.get_version.outputs.image_tag }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+  deploy-if-prerelease:
+    if: github.event.release.prerelease == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Extract version from build.gradle
+        id: get_version
+        run: |
+          VERSION=$(grep '^version\s*=' app/build.gradle | sed 's/version\s*=\s*["'\'']\([^"'\'']*\)["'\'']/\1/')
+          echo "Detected version: $VERSION"
+          echo "image_tag=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger Testing Deployment
+        run: |
+          gh workflow run deploy-to-azure-vm.yml \
+            --ref "main" \
+            -f environment=Staging \
+            -f imageTag=${{ steps.get_version.outputs.image_tag }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Description
This PR introduces a Continuous Deployment (CD) workflow that supports deployment to both **Staging** and **Production** environments. It enables automated, environment-specific deployment triggered by branch, tag, or manual approval.

## Changes
* Added separate deployment jobs or steps for Staging and Production
* Configured environment variables and secrets specific to each environment
* Implemented gating or approval steps for Production deployment (optional)
* Ensured smooth promotion from Staging to Production with minimal manual intervention

## Related Issues
* Supports environment-based deployment strategy
* Improves release process reliability and consistency

## Testing
* Tested deployment to Staging environment on feature branches or pull requests
* Verified Production deployment triggers only on main/release branches or via manual approval
* Monitored logs and application behavior post-deployment in both environments

## Checklist
* [x] I have tested the workflow in a test repository or branch.
* [x] I have verified environment-specific configurations.
* [x] I have ensured secrets and credentials are securely handled.
* [x] I have documented the deployment process as needed.
